### PR TITLE
fix: deepcopy clamp_params!

### DIFF
--- a/src/aind_dynamic_foraging_models/generative_model/base.py
+++ b/src/aind_dynamic_foraging_models/generative_model/base.py
@@ -332,6 +332,7 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
         # Validate fit_bounds_override and fill in the missing bounds with default bounds
         fit_bounds = self.ParamFitBoundModel(**fit_bounds_override).model_dump()
         # Add agent's frozen parameters (by construction) to clamp_params (user specified)
+        clamp_params = clamp_params.deepcopy()  # Make a copy to avoid modifying the default dict!!
         clamp_params.update(self.params_list_frozen)
         # Remove clamped parameters from fit_bounds
         for name in clamp_params.keys():

--- a/src/aind_dynamic_foraging_models/generative_model/base.py
+++ b/src/aind_dynamic_foraging_models/generative_model/base.py
@@ -332,7 +332,7 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
         # Validate fit_bounds_override and fill in the missing bounds with default bounds
         fit_bounds = self.ParamFitBoundModel(**fit_bounds_override).model_dump()
         # Add agent's frozen parameters (by construction) to clamp_params (user specified)
-        clamp_params = clamp_params.deepcopy()  # Make a copy to avoid modifying the default dict!!
+        clamp_params = clamp_params.copy()  # Make a copy to avoid modifying the default dict!!
         clamp_params.update(self.params_list_frozen)
         # Remove clamped parameters from fit_bounds
         for name in clamp_params.keys():

--- a/tests/test_RescorlaWagner.py
+++ b/tests/test_RescorlaWagner.py
@@ -59,14 +59,6 @@ class TestRescorlaWagner(unittest.TestCase):
             choice_history,
             reward_history,
             DE_kwargs=dict(workers=mp.cpu_count(), disp=False, seed=np.random.default_rng(42)),
-            clamp_params={},  # I saw a very weird python bug (?) that if I don't specify this
-            # and run coverage -m unittest discover, somehow the clamp_params
-            # in this test will be affected by a previous run of test_Bari.py.
-            # Interestingly, all tests pass if I run them individually.
-            # This should have something to do with the clamp_params.update()
-            # in .fit() method. If I don't specify it, maybe the .fit() function
-            # of all the tests try to access the default value from the same
-            # memory address, which leads to the weird cross talk...
             k_fold_cross_validation=None,
         )
 

--- a/tests/test_loss_counting.py
+++ b/tests/test_loss_counting.py
@@ -63,14 +63,6 @@ class TestLossCounting(unittest.TestCase):
         forager.fit(
             choice_history,
             reward_history,
-            clamp_params={},  # I saw a very weird python bug (?) that if I don't specify this
-            # and run coverage -m unittest discover, somehow the clamp_params
-            # in this test will be affected by a previous run of test_Bari.py.
-            # Interestingly, all tests pass if I run them individually.
-            # This should have something to do with the clamp_params.update()
-            # in .fit() method. If I don't specify it, maybe the .fit() function
-            # of all the tests try to access the default value from the same
-            # memory address, which leads to the weird cross talk...
             DE_kwargs=dict(workers=mp.cpu_count(), disp=False, seed=np.random.default_rng(42)),
             k_fold_cross_validation=None,
         )


### PR DESCRIPTION
- Solved a bug where `clamp_params.update()` will affect its default value in subsequent runs.
- See this minimal example
```python
>>> def func(d={}):
        print(d)
        d.update(a=1)

    func()
    func()

{}
{'a': 1}
```