### PR TITLE
feat: add get_fitting_result_dict

### DIFF
--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.9', '3.10' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,7 @@ html_show_copyright = False
 
 # Add source code link
 html_show_sourcelink = True
-html_sourcelink_suffix = ''
+html_sourcelink_suffix = ""
 
 # --- Substitutions ---
 rst_epilog = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "aind-dynamic-foraging-models"
 description = "Generated from aind-library-template"
 license = {text = "MIT"}
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 authors = [
     {name = "Allen Institute for Neural Dynamics"}
 ]

--- a/src/aind_dynamic_foraging_models/generative_model/base.py
+++ b/src/aind_dynamic_foraging_models/generative_model/base.py
@@ -548,6 +548,36 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
         fitting_result.LPT_AIC = np.exp(-fitting_result.AIC / 2 / fitting_result.n_trials)
         fitting_result.LPT_BIC = np.exp(-fitting_result.BIC / 2 / fitting_result.n_trials)
 
+        # Always save the result without polishing, regardless of the polish setting
+        # (sometimes polishing will move parameters to boundaries, so I add this for sanity check)
+        # - About `polish` in DE:
+        #   - If `polish=False`, final `x` will be exactly the one in `population` that has the 
+        #     lowest `population_energy` (typically the first one). 
+        #     Its energy will also be the final `-log_likelihood`.
+        #   - If `polish=True`, an additional gradient-based optimization will
+        #     work on `population[0]`, resulting in the final `x`, and override the likelihood 
+        #     `population_energy[0]` . But it will not change `population[0]`!
+        #   - That is to say, `population[0]` is always the result without `polish`.
+        #     And if polished, we should rerun a `_cost_func_for_DE` to retrieve 
+        #     its likelihood, because it has been overridden by `x`.
+        idx_lowest_energy = fitting_result.population_energies.argmin()
+        x_without_polishing = fitting_result.population[idx_lowest_energy]
+
+        log_likelihood_without_polishing = -self._cost_func_for_DE(
+            x_without_polishing,                 
+            agent_kwargs,  # Other kwargs to pass to the model
+            fit_choice_history,
+            fit_reward_history,
+            fit_trial_set,  # subset of trials to fit; if empty, use all trials)
+            fit_names,  # Pass names so that negLL_func_for_de knows which parameters to fit
+            clamp_params,
+        )
+        fitting_result.x_without_polishing = x_without_polishing
+        fitting_result.log_likelihood_without_polishing = log_likelihood_without_polishing
+        
+        params_without_polishing = dict(zip(fit_names, fitting_result.x_without_polishing))
+        params_without_polishing.update(clamp_params)
+        fitting_result.params_without_polishing = params_without_polishing
         return fitting_result
 
     @classmethod
@@ -701,10 +731,11 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
         else:
             fit_settings.pop("fit_choice_history")
             fit_settings.pop("fit_reward_history")
-            
+
         # -- fit_stats --
         fit_stats = {}
         fit_stats_fields = [
+            "params",
             "log_likelihood",
             "AIC",
             "BIC",
@@ -718,6 +749,8 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
             "success",
             "population",
             "population_energies",
+            "params_without_polishing",
+            "log_likelihood_without_polishing",
         ]
         for field in fit_stats_fields:
             value = fitting_result_object[field]
@@ -729,7 +762,6 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
 
         return {
             "fit_settings": fit_settings,
-            "fitted_params": fitting_result_object.params,
             **fit_stats,
         }
 
@@ -767,7 +799,7 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
                 "prediction_accuracy_test_bias_only":
                     self.fitting_result_cross_validation["prediction_accuracy_test_bias_only"],
                 }
-            
+
             # Fitting results of each fold
             fitting_results_each_fold = {}
             for kk, fitting_result_fold in enumerate(

--- a/src/aind_dynamic_foraging_models/generative_model/base.py
+++ b/src/aind_dynamic_foraging_models/generative_model/base.py
@@ -742,7 +742,7 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
         """
         if self.fitting_result is None:
             print("No fitting result found. Please fit the model first.")
-        return
+            return
 
         # -- result of fitting with all data --
         dict_all_data = self._fitting_result_to_dict(

--- a/src/aind_dynamic_foraging_models/generative_model/base.py
+++ b/src/aind_dynamic_foraging_models/generative_model/base.py
@@ -492,6 +492,7 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
             mutation=(0.5, 1),
             recombination=0.7,
             popsize=16,
+            polish=True,
             strategy="best1bin",
             disp=False,
             workers=1,

--- a/src/aind_dynamic_foraging_models/generative_model/base.py
+++ b/src/aind_dynamic_foraging_models/generative_model/base.py
@@ -551,20 +551,20 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
         # Always save the result without polishing, regardless of the polish setting
         # (sometimes polishing will move parameters to boundaries, so I add this for sanity check)
         # - About `polish` in DE:
-        #   - If `polish=False`, final `x` will be exactly the one in `population` that has the 
-        #     lowest `population_energy` (typically the first one). 
+        #   - If `polish=False`, final `x` will be exactly the one in `population` that has the
+        #     lowest `population_energy` (typically the first one).
         #     Its energy will also be the final `-log_likelihood`.
         #   - If `polish=True`, an additional gradient-based optimization will
-        #     work on `population[0]`, resulting in the final `x`, and override the likelihood 
+        #     work on `population[0]`, resulting in the final `x`, and override the likelihood
         #     `population_energy[0]` . But it will not change `population[0]`!
         #   - That is to say, `population[0]` is always the result without `polish`.
-        #     And if polished, we should rerun a `_cost_func_for_DE` to retrieve 
+        #     And if polished, we should rerun a `_cost_func_for_DE` to retrieve
         #     its likelihood, because it has been overridden by `x`.
         idx_lowest_energy = fitting_result.population_energies.argmin()
         x_without_polishing = fitting_result.population[idx_lowest_energy]
 
         log_likelihood_without_polishing = -self._cost_func_for_DE(
-            x_without_polishing,                 
+            x_without_polishing,
             agent_kwargs,  # Other kwargs to pass to the model
             fit_choice_history,
             fit_reward_history,
@@ -574,7 +574,7 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
         )
         fitting_result.x_without_polishing = x_without_polishing
         fitting_result.log_likelihood_without_polishing = log_likelihood_without_polishing
-        
+
         params_without_polishing = dict(zip(fit_names, fitting_result.x_without_polishing))
         params_without_polishing.update(clamp_params)
         fitting_result.params_without_polishing = params_without_polishing
@@ -710,7 +710,7 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
 
     def get_latent_variables(self):
         """Return the latent variables of the agent
-        
+
         This is agent-specific and should be implemented by the subclass.
         """
         return None
@@ -718,7 +718,7 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
     @staticmethod
     def _fitting_result_to_dict(fitting_result_object, if_include_choice_reward_history=True):
         """Turn each fitting_result object (all data or cross-validation) into a dict
-        
+
         if_include_choice_reward_history: whether to include choice and reward history in the dict.
         To save space, we may not want to include them for each fold in cross-validation.
         """
@@ -766,8 +766,7 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
         }
 
     def get_fitting_result_dict(self):
-        """Return the fitting result in a json-compatible dict for uploading to docDB etc.
-        """
+        """Return the fitting result in a json-compatible dict for uploading to docDB etc."""
         if self.fitting_result is None:
             print("No fitting result found. Please fit the model first.")
             return
@@ -792,13 +791,16 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
         if self.fitting_result_cross_validation is not None:
             # Overall goodness of fit
             cross_validation = {
-                "prediction_accuracy_test": 
-                    self.fitting_result_cross_validation["prediction_accuracy_test"],
-                "prediction_accuracy_fit":
-                    self.fitting_result_cross_validation["prediction_accuracy_fit"],
-                "prediction_accuracy_test_bias_only":
-                    self.fitting_result_cross_validation["prediction_accuracy_test_bias_only"],
-                }
+                "prediction_accuracy_test": self.fitting_result_cross_validation[
+                    "prediction_accuracy_test"
+                ],
+                "prediction_accuracy_fit": self.fitting_result_cross_validation[
+                    "prediction_accuracy_fit"
+                ],
+                "prediction_accuracy_test_bias_only": self.fitting_result_cross_validation[
+                    "prediction_accuracy_test_bias_only"
+                ],
+            }
 
             # Fitting results of each fold
             fitting_results_each_fold = {}
@@ -812,6 +814,7 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
             fitting_result_dict["cross_validation"] = cross_validation
 
         return fitting_result_dict
+
 
 # -- Helper function --
 def negLL(choice_prob, fit_choice_history, fit_reward_history, fit_trial_set=None):

--- a/src/aind_dynamic_foraging_models/generative_model/forager_loss_counting.py
+++ b/src/aind_dynamic_foraging_models/generative_model/forager_loss_counting.py
@@ -121,7 +121,7 @@ class ForagerLossCounting(DynamicForagingAgentMLEBase):
                 choice_kernel_tminus1=self.choice_kernel[:, self.trial - 1],
                 choice_kernel_step_size=self.params.choice_kernel_step_size,
             )
-            
+
     def get_latent_variables(self):
         return {
             "loss_count": self.loss_count.tolist(),

--- a/src/aind_dynamic_foraging_models/generative_model/forager_loss_counting.py
+++ b/src/aind_dynamic_foraging_models/generative_model/forager_loss_counting.py
@@ -121,6 +121,13 @@ class ForagerLossCounting(DynamicForagingAgentMLEBase):
                 choice_kernel_tminus1=self.choice_kernel[:, self.trial - 1],
                 choice_kernel_step_size=self.params.choice_kernel_step_size,
             )
+            
+    def get_latent_variables(self):
+        return {
+            "loss_count": self.loss_count.tolist(),
+            "choice_kernel": self.choice_kernel.tolist(),
+            "choice_prob": self.choice_prob.tolist(),
+        }
 
     def plot_latent_variables(self, ax, if_fitted=False):
         """Plot Q values"""

--- a/src/aind_dynamic_foraging_models/generative_model/forager_q_learning.py
+++ b/src/aind_dynamic_foraging_models/generative_model/forager_q_learning.py
@@ -154,6 +154,13 @@ class ForagerQLearning(DynamicForagingAgentMLEBase):
                 choice_kernel_step_size=self.params.choice_kernel_step_size,
             )
 
+    def get_latent_variables(self):
+        return {
+            "q_value": self.q_value.tolist(),
+            "choice_kernel": self.choice_kernel.tolist(),
+            "choice_prob": self.choice_prob.tolist(),
+        }
+
     def plot_latent_variables(self, ax, if_fitted=False):
         """Plot Q values"""
         if if_fitted:

--- a/tests/test_Bari.py
+++ b/tests/test_Bari.py
@@ -76,10 +76,9 @@ class TestBari(unittest.TestCase):
         print(f'Fitted:       {[f"{num:.4f}" for num in fitting_result.x]}')
         print(f"Likelihood-Per-Trial: {fitting_result.LPT}")
         print(f"Prediction accuracy full dataset: {fitting_result.prediction_accuracy}\n")
-        
+
         # Check get_fitting_result_dict
-        fitting_result_dict = forager.get_fitting_result_dict()
-        
+        forager.get_fitting_result_dict()
 
         # Plot fitted latent variables
         fig_fitting, axes = forager.plot_fitted_session(if_plot_latent=True)

--- a/tests/test_Bari.py
+++ b/tests/test_Bari.py
@@ -76,6 +76,10 @@ class TestBari(unittest.TestCase):
         print(f'Fitted:       {[f"{num:.4f}" for num in fitting_result.x]}')
         print(f"Likelihood-Per-Trial: {fitting_result.LPT}")
         print(f"Prediction accuracy full dataset: {fitting_result.prediction_accuracy}\n")
+        
+        # Check get_fitting_result_dict
+        fitting_result_dict = forager.get_fitting_result_dict()
+        
 
         # Plot fitted latent variables
         fig_fitting, axes = forager.plot_fitted_session(if_plot_latent=True)

--- a/tests/test_RescorlaWagner.py
+++ b/tests/test_RescorlaWagner.py
@@ -64,6 +64,9 @@ class TestRescorlaWagner(unittest.TestCase):
 
         fitting_result = forager.fitting_result
         assert fitting_result.success
+        
+        # Check get_fitting_result_dict
+        fitting_result_dict = forager.get_fitting_result_dict()
 
         # Check fitted parameters
         fit_names = fitting_result.fit_settings["fit_names"]

--- a/tests/test_RescorlaWagner.py
+++ b/tests/test_RescorlaWagner.py
@@ -64,9 +64,9 @@ class TestRescorlaWagner(unittest.TestCase):
 
         fitting_result = forager.fitting_result
         assert fitting_result.success
-        
+
         # Check get_fitting_result_dict
-        fitting_result_dict = forager.get_fitting_result_dict()
+        forager.get_fitting_result_dict()
 
         # Check fitted parameters
         fit_names = fitting_result.fit_settings["fit_names"]

--- a/tests/test_loss_counting.py
+++ b/tests/test_loss_counting.py
@@ -69,9 +69,9 @@ class TestLossCounting(unittest.TestCase):
 
         fitting_result = forager.fitting_result
         assert fitting_result.success
-        
+
         # Check get_fitting_result_dict
-        fitting_result_dict = forager.get_fitting_result_dict()
+        forager.get_fitting_result_dict()
 
         # Check fitted parameters
         fit_names = fitting_result.fit_settings["fit_names"]

--- a/tests/test_loss_counting.py
+++ b/tests/test_loss_counting.py
@@ -69,6 +69,9 @@ class TestLossCounting(unittest.TestCase):
 
         fitting_result = forager.fitting_result
         assert fitting_result.success
+        
+        # Check get_fitting_result_dict
+        fitting_result_dict = forager.get_fitting_result_dict()
 
         # Check fitted parameters
         fit_names = fitting_result.fit_settings["fit_names"]


### PR DESCRIPTION
- Add method `get_fitting_result_dict` to return a json-compatible dictionary for docDB inserting. 
- Example resulting json:
```python
{
    "fit_settings": {
        "fit_choice_history": [
       ...
        ],
        "fit_reward_history": [
       ...
        ],
        "fit_names": [
            "learn_rate_rew",
            "learn_rate_unrew",
            "forget_rate_unchosen",
            "softmax_inverse_temperature"
        ],
        "lower_bounds": [
            0.0,
            0.0,
            0.0,
            0.0
        ],
        "upper_bounds": [
            1.0,
            1.0,
            1.0,
            100.0
        ],
        "clamp_params": {
            "biasL": 0
        },
        "agent_kwargs": {
            "number_of_learning_rate": 2,
            "number_of_forget_rate": 1,
            "choice_kernel": "none",
            "action_selection": "softmax"
        }
    },
    "params": {
        "learn_rate_rew": 0.6033178889116801,
        "learn_rate_unrew": 0.19876389091937388,
        "forget_rate_unchosen": 0.2559107382027955,
        "softmax_inverse_temperature": 5.359943069348114,
        "biasL": 0
    },
    "log_likelihood": -24.48229546352151,
    "AIC": 56.96459092704302,
    "BIC": 67.38527167099538,
    "LPT": 0.7828431247200448,
    "LPT_AIC": 0.752147406744024,
    "LPT_BIC": 0.7139614152599313,
    "k_model": 4,
    "n_trials": 100,
    "nfev": 2197,
    "nit": 32,
    "success": true,
    "population": [
        [
            0.607805498632581,
            0.1998445971938479,
            0.25454867132718245,
            5.401614141060691
        ],
        [
            0.6273588117636638,
            0.1820512849102367,
            0.2773155713866274,
            5.1717676673875985
        ],
        [
            0.603994557337677,
            0.20266826161618628,
            0.2830859917267101,
            5.214265799215177
        ],
        [
            0.6229843461039541,
            0.181627730314744,
            0.2666788180150571,
            5.235148374808858
        ],
        [
            0.5815441885238286,
            0.2053212086810129,
            0.21185570700420314,
            5.516733165984334
        ],
        [
            0.6206316664294255,
            0.22125396918421408,
            0.2766686074428202,
            5.5229907050262455
        ],
...

``` 