### PR TITLE
fix: turn DE_seed to np rng if it is an int

### DIFF
--- a/src/aind_dynamic_foraging_models/generative_model/base.py
+++ b/src/aind_dynamic_foraging_models/generative_model/base.py
@@ -507,8 +507,13 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
             callback=None,
         )  # Default DE kwargs
         kwargs.update(DE_kwargs)  # Update user specified kwargs
+        # Special treatments
         if kwargs["workers"] > 1:
             kwargs["updating"] = "deferred"
+        if "seed" in kwargs and isinstance(kwargs["seed"], (int, float)):
+            # Convert seed to a numpy random number generator
+            # because there seems to be a bug in DE when using int as a seed (not reproducible)
+            kwargs["seed"] = np.random.default_rng(kwargs["seed"])
 
         # --- Heavy lifting here!! ---
         fitting_result = optimize.differential_evolution(


### PR DESCRIPTION
- fix a DE bug(?) that if using an integer for the seed, the computation is not reproducible.