### PR TITLE
hotfix: symbol bug

### DIFF
--- a/src/aind_dynamic_foraging_models/generative_model/base.py
+++ b/src/aind_dynamic_foraging_models/generative_model/base.py
@@ -131,7 +131,7 @@ class DynamicForagingAgentMLEBase(DynamicForagingAgentBase):
 
         ps = []
         for p in params_list:
-            name_str = ParamsSymbols[p[0]] if if_latex else p[0]
+            name_str = ParamsSymbols[p[0]].value if if_latex else p[0]
             value_str = f" = {p[1]:.{decimal}f}" if if_value else ""
             fix_str = " (fixed)" if p[0] in fixed_params else ""
             ps.append(f"{name_str}{value_str}{fix_str}")


### PR DESCRIPTION
Fix a minor bug in the figure legend where parameter is not shown in latex. This should a python version or pydantic version issue.