### PR TITLE
feat(generative_model): add actor-critic forager with MLE fitting and choice-kernel support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,4 +145,4 @@ dmypy.json
 /metadata
 /.codeocean
 
-tests/results/
+tests/results/*.patch

--- a/add_actor_critic.patch
+++ b/add_actor_critic.patch
@@ -1,0 +1,530 @@
+diff --git a/src/aind_dynamic_foraging_models/generative_model/__init__.py b/src/aind_dynamic_foraging_models/generative_model/__init__.py
+index ee6d32f..021d649 100644
+--- a/src/aind_dynamic_foraging_models/generative_model/__init__.py
++++ b/src/aind_dynamic_foraging_models/generative_model/__init__.py
+@@ -1,6 +1,7 @@
+ """Package for generative models of dynamic foraging behavior"""
+ 
+ # Register the forager classes here
++from .forager_actor_critic import ForagerActorCritic  # noqa: F401
+ from .forager_compare_threshold import ForagerCompareThreshold  # noqa: F401
+ from .forager_loss_counting import ForagerLossCounting  # noqa: F401
+ from .forager_q_learning import ForagerQLearning  # noqa: F401
+diff --git a/src/aind_dynamic_foraging_models/generative_model/forager_actor_critic.py b/src/aind_dynamic_foraging_models/generative_model/forager_actor_critic.py
+new file mode 100644
+index 0000000..2c554e4
+--- /dev/null
++++ b/src/aind_dynamic_foraging_models/generative_model/forager_actor_critic.py
+@@ -0,0 +1,203 @@
++"""Actor-critic foraging model with MLE fitting.
++
++This implements the classic (Sutton & Barto) actor-critic architecture adapted to a
++two-armed dynamic foraging task, following the same design pattern as
++:class:`~aind_dynamic_foraging_models.generative_model.forager_q_learning.ForagerQLearning`
++so that it plugs directly into the existing MLE / differential-evolution fitting pipeline.
++
++Two latent variables are tracked:
++
++- **Actor** ``H``: a per-action preference. Actions are selected by a softmax over ``H``
++  (plus an optional left bias and choice kernel).
++- **Critic** ``V``: a single (state-less) state value that serves as a reward baseline.
++
++Both are taught by the same TD error ``delta_t = reward_t - V_{t-1}`` (there is no
++bootstrap term because the task is effectively a single-state bandit). See
++:func:`~aind_dynamic_foraging_models.generative_model.learn_functions.learn_actor_critic`.
++"""
++
++# %%
++from typing import Literal
++
++import numpy as np
++from aind_behavior_gym.dynamic_foraging.task import L, R
++
++from .act_functions import act_softmax
++from .base import DynamicForagingAgentMLEBase
++from .learn_functions import learn_actor_critic, learn_choice_kernel
++from .params.forager_actor_critic_params import generate_pydantic_actor_critic_params
++
++
++class ForagerActorCritic(DynamicForagingAgentMLEBase):
++    """The family of actor-critic models (softmax actor + state-value critic)."""
++
++    def __init__(
++        self,
++        choice_kernel: Literal["none", "one_step", "full"] = "none",
++        params: dict = {},
++        **kwargs,
++    ):
++        """Init
++
++        Parameters
++        ----------
++        choice_kernel : Literal["none", "one_step", "full"], optional
++            Choice kernel type, by default "none"
++            If "none", no choice kernel will be included in the model.
++            If "one_step", choice_kernel_step_size will be set to 1.0, i.e., only the last choice
++                affects the choice kernel. (Bari2019)
++            If "full", both choice_kernel_step_size and choice_kernel_relative_weight
++            will be included during fitting.
++        params: dict, optional
++            Initial parameters of the model, by default {}.
++            See the generated Pydantic model in forager_actor_critic_params.py for the full
++            list of parameters (learn_rate_actor, learn_rate_critic, biasL,
++            softmax_inverse_temperature, and optionally choice-kernel parameters).
++
++        Notes
++        -----
++        The action selection is always a softmax over the actor preferences, so the
++        actor's learning-rate scale (``learn_rate_actor``) trades off with the softmax
++        inverse temperature (``softmax_inverse_temperature``). These are not jointly
++        identifiable; when fitting, it is recommended to clamp the inverse temperature,
++        e.g. ``forager.fit(..., clamp_params={"softmax_inverse_temperature": 1.0})``.
++        """
++        # -- Pack the agent_kwargs --
++        self.agent_kwargs = dict(
++            choice_kernel=choice_kernel,
++        )  # Note that the class and self.agent_kwargs fully define the agent
++
++        # -- Initialize the model parameters --
++        super().__init__(agent_kwargs=self.agent_kwargs, params=params, **kwargs)
++
++        # -- Some agent-family-specific variables --
++        self.fit_choice_kernel = False
++
++    def _get_params_model(self, agent_kwargs):
++        """Implement the base class method to dynamically generate Pydantic models
++        for parameters and fitting bounds for the actor-critic agent.
++        """
++        return generate_pydantic_actor_critic_params(**agent_kwargs)
++
++    def get_agent_alias(self):
++        """Get the agent alias"""
++        _ck = {"none": "", "one_step": "_CK1", "full": "_CKfull"}[
++            self.agent_kwargs["choice_kernel"]
++        ]
++        return "ActorCritic" + _ck
++
++    def _reset(self):
++        """Reset the agent"""
++        # --- Call the base class reset ---
++        super()._reset()
++
++        # --- Agent family specific variables ---
++        # Latent variables have n_trials + 1 length to capture the update
++        # after the last trial (consistent with ForagerQLearning).
++        # Actor preference H (one per action)
++        self.actor_preference = np.full([self.n_actions, self.n_trials + 1], np.nan)
++        self.actor_preference[:, 0] = 0  # Initial actor preferences as 0
++
++        # Critic state value V (scalar, state-less bandit)
++        self.value = np.full(self.n_trials + 1, np.nan)
++        self.value[0] = 0  # Initial value as 0
++
++        # Always initialize choice_kernel with nan, even if choice_kernel = "none"
++        self.choice_kernel = np.full([self.n_actions, self.n_trials + 1], np.nan)
++        self.choice_kernel[:, 0] = 0  # Initial choice kernel as 0
++
++    def act(self, _):
++        """Action selection (softmax over actor preferences)"""
++        # Handle choice kernel
++        if self.agent_kwargs["choice_kernel"] == "none":
++            choice_kernel = None
++            choice_kernel_relative_weight = None
++        else:
++            choice_kernel = self.choice_kernel[:, self.trial]
++            choice_kernel_relative_weight = self.params.choice_kernel_relative_weight
++
++        # Action selection: the actor preference plays the role of "q_value" in the softmax
++        choice, choice_prob = act_softmax(
++            q_value_t=self.actor_preference[:, self.trial],
++            softmax_inverse_temperature=self.params.softmax_inverse_temperature,
++            bias_terms=np.array([self.params.biasL, 0]),
++            # -- Choice kernel --
++            choice_kernel=choice_kernel,
++            choice_kernel_relative_weight=choice_kernel_relative_weight,
++            rng=self.rng,
++        )
++
++        return choice, choice_prob
++
++    def learn(self, _observation, choice, reward, _next_observation, done):
++        """Update actor preferences and critic value.
++
++        Note that self.trial already increased by 1 before learn() in the base class,
++        so the policy used to make this trial's choice is choice_prob[:, self.trial - 1].
++        """
++        # The policy (choice probability) that was actually used to make this choice
++        policy_prob = self.choice_prob[:, self.trial - 1]
++
++        # Update actor preference and critic value
++        self.actor_preference[:, self.trial], self.value[self.trial] = learn_actor_critic(
++            choice=choice,
++            reward=reward,
++            actor_preference_tminus1=self.actor_preference[:, self.trial - 1],
++            value_tminus1=self.value[self.trial - 1],
++            choice_prob_t=policy_prob,
++            learn_rates=[self.params.learn_rate_actor, self.params.learn_rate_critic],
++        )
++
++        # Update choice kernel, if used
++        if self.agent_kwargs["choice_kernel"] != "none":
++            self.choice_kernel[:, self.trial] = learn_choice_kernel(
++                choice=choice,
++                choice_kernel_tminus1=self.choice_kernel[:, self.trial - 1],
++                choice_kernel_step_size=self.params.choice_kernel_step_size,
++            )
++
++    def get_latent_variables(self):
++        return {
++            "actor_preference": self.actor_preference.tolist(),
++            "value": self.value.tolist(),
++            "choice_kernel": self.choice_kernel.tolist(),
++            "choice_prob": self.choice_prob.tolist(),
++        }
++
++    def plot_latent_variables(self, ax, if_fitted=False):
++        """Plot actor preferences and critic value"""
++        if if_fitted:
++            style = dict(lw=2, ls=":")
++            prefix = "fitted_"
++        else:
++            style = dict(lw=0.5)
++            prefix = ""
++
++        x = np.arange(self.n_trials + 1) + 1  # When plotting, we start from 1
++
++        # -- Actor preferences --
++        ax.plot(x, self.actor_preference[L, :], label=f"{prefix}H(L)", color="red", **style)
++        ax.plot(x, self.actor_preference[R, :], label=f"{prefix}H(R)", color="blue", **style)
++
++        # -- Critic value (shared baseline) on a twin axis for readability --
++        ax_value = ax.twinx() if not hasattr(ax, "_ac_value_twin") else ax._ac_value_twin
++        ax._ac_value_twin = ax_value
++        ax_value.plot(x, self.value, label=f"{prefix}V", color="black", **style)
++        ax_value.set_ylabel("critic value V")
++
++        # Add choice kernel, if used
++        if self.agent_kwargs["choice_kernel"] != "none":
++            ax.plot(
++                x,
++                self.choice_kernel[L, :],
++                label=f"{prefix}choice_kernel(L)",
++                color="purple",
++                **style,
++            )
++            ax.plot(
++                x,
++                self.choice_kernel[R, :],
++                label=f"{prefix}choice_kernel(R)",
++                color="cyan",
++                **style,
++            )
+diff --git a/src/aind_dynamic_foraging_models/generative_model/foragers.py b/src/aind_dynamic_foraging_models/generative_model/foragers.py
+index ca380e1..2b8a77f 100644
+--- a/src/aind_dynamic_foraging_models/generative_model/foragers.py
++++ b/src/aind_dynamic_foraging_models/generative_model/foragers.py
+@@ -16,6 +16,7 @@ class ForagerCollection:
+         "ForagerQLearning",
+         "ForagerLossCounting",
+         "ForagerCompareThreshold",
++        "ForagerActorCritic",
+     ]
+ 
+     FORAGER_PRESETS = {
+@@ -64,6 +65,13 @@ class ForagerCollection:
+                 choice_kernel="none",
+             ),
+         ),
++        "ActorCritic": dict(
++            description="Vanilla actor-critic model (softmax actor + state-value critic)",
++            agent_class="ForagerActorCritic",
++            agent_kwargs=dict(
++                choice_kernel="none",
++            ),
++        ),
+     }
+ 
+     def __init__(self):
+diff --git a/src/aind_dynamic_foraging_models/generative_model/learn_functions.py b/src/aind_dynamic_foraging_models/generative_model/learn_functions.py
+index 2b0c1aa..4c2f77a 100644
+--- a/src/aind_dynamic_foraging_models/generative_model/learn_functions.py
++++ b/src/aind_dynamic_foraging_models/generative_model/learn_functions.py
+@@ -85,3 +85,81 @@ def learn_loss_counting(choice, reward, just_switched, loss_count_tminus1) -> in
+         return 1
+     else:
+         return loss_count_tminus1 + 1
++
++
++def learn_actor_critic(
++    choice,
++    reward,
++    actor_preference_tminus1,
++    value_tminus1,
++    choice_prob_t,
++    learn_rates,
++):
++    """One-step actor-critic update for a (state-less) two-armed foraging task.
++
++    This implements the classic Sutton & Barto actor-critic with a softmax actor:
++
++    1. Critic (state value V) is updated by the TD error. Because the dynamic
++       foraging task is effectively state-less (a single state / bandit), there is
++       no bootstrap term, so the TD error reduces to the reward-prediction error::
++
++           delta_t = reward_t - V_{t-1}
++           V_t     = V_{t-1} + alpha_critic * delta_t
++
++       Here V acts as a running reward baseline shared across actions.
++
++    2. Actor (per-action preference H) is updated along the softmax policy gradient,
++       using the same TD error as the critic's teaching signal::
++
++           H_t(a) = H_{t-1}(a) + alpha_actor * delta_t * (1{a == choice} - pi(a))
++
++       where ``pi`` is the policy (choice probability) that was actually used to
++       select the action on this trial.
++
++    Parameters
++    ----------
++    choice : int
++        This trial's choice (action index).
++    reward : float
++        This trial's reward.
++    actor_preference_tminus1 : np.ndarray
++        Array of old actor preferences H, one entry per action.
++    value_tminus1 : float
++        Old critic state value V (scalar).
++    choice_prob_t : np.ndarray
++        The policy pi (choice probability per action) that was used to make this
++        trial's choice. Used for the softmax policy-gradient term.
++    learn_rates : list
++        Learning rates as [alpha_actor, alpha_critic].
++
++    Returns
++    -------
++    tuple(np.ndarray, float)
++        (new actor preferences H, new critic value V)
++
++    Notes
++    -----
++    The actor's overall scale (alpha_actor) and the policy's softmax inverse
++    temperature (beta) are not jointly identifiable, because both scale the
++    preferences inside the softmax. When fitting, it is therefore recommended to
++    clamp ``softmax_inverse_temperature`` (e.g. to 1.0) and let ``learn_rate_actor``
++    absorb the scale. For that reason, beta is intentionally *not* multiplied into
++    the actor gradient here.
++    """
++    learn_rate_actor, learn_rate_critic = learn_rates[0], learn_rates[1]
++
++    # -- TD error (state-less reward-prediction error) --
++    td_error = reward - value_tminus1
++
++    # -- Critic update --
++    value_t = value_tminus1 + learn_rate_critic * td_error
++
++    # -- Actor update (softmax policy gradient) --
++    K = actor_preference_tminus1.shape[0]
++    choice_onehot = np.zeros(K)
++    choice_onehot[choice] = 1.0
++    actor_preference_t = actor_preference_tminus1 + learn_rate_actor * td_error * (
++        choice_onehot - np.asarray(choice_prob_t)
++    )
++
++    return actor_preference_t, value_t
+diff --git a/src/aind_dynamic_foraging_models/generative_model/params/__init__.py b/src/aind_dynamic_foraging_models/generative_model/params/__init__.py
+index adb87a2..d4f3e55 100644
+--- a/src/aind_dynamic_foraging_models/generative_model/params/__init__.py
++++ b/src/aind_dynamic_foraging_models/generative_model/params/__init__.py
+@@ -14,6 +14,8 @@ class ParamsSymbols(str, Enum):
+     learn_rate = R"$\alpha$"
+     learn_rate_rew = R"$\alpha_{rew}$"
+     learn_rate_unrew = R"$\alpha_{unr}$"
++    learn_rate_actor = R"$\alpha_{actor}$"
++    learn_rate_critic = R"$\alpha_{critic}$"
+     forget_rate_unchosen = R"$\delta$"
+     choice_kernel_step_size = R"$\alpha_{ck}$"
+     choice_kernel_relative_weight = R"$w_{ck}$"
+diff --git a/src/aind_dynamic_foraging_models/generative_model/params/forager_actor_critic_params.py b/src/aind_dynamic_foraging_models/generative_model/params/forager_actor_critic_params.py
+new file mode 100644
+index 0000000..3ea2209
+--- /dev/null
++++ b/src/aind_dynamic_foraging_models/generative_model/params/forager_actor_critic_params.py
+@@ -0,0 +1,70 @@
++"""Dynamically generate pydantic models for actor-critic agent parameters."""
++
++# %%
++from typing import Literal, Tuple, Type
++
++from pydantic import BaseModel, Field
++
++from .forager_q_learning_params import (
++    _add_action_selection_fields,
++    _add_choice_kernel_fields,
++)
++from .util import create_pydantic_models_dynamic
++
++
++def generate_pydantic_actor_critic_params(
++    choice_kernel: Literal["none", "one_step", "full"] = "none",
++) -> Tuple[Type[BaseModel], Type[BaseModel]]:
++    """Dynamically generate Pydantic models for actor-critic agent parameters.
++
++    All default values are hard-coded in this function. But when instantiating the model,
++    you can always override the default values, both the params_fields and the fitting bounds.
++
++    Parameters
++    ----------
++    choice_kernel : Literal["none", "one_step", "full"], optional
++        Choice kernel type, by default "none"
++        If "none", no choice kernel will be included in the model.
++        If "one_step", choice_kernel_step_size will be set to 1.0, i.e., only the previous choice
++            affects the choice kernel. (Bari2019)
++        If "full", both choice_kernel_step_size and choice_kernel_relative_weight will be included
++
++    Notes
++    -----
++    The actor-critic agent always uses a softmax actor, so ``biasL`` and
++    ``softmax_inverse_temperature`` (beta) are always included via the shared
++    action-selection helper. Note that ``learn_rate_actor`` and ``beta`` are not
++    jointly identifiable; it is recommended to clamp ``softmax_inverse_temperature``
++    when fitting (e.g. ``clamp_params={"softmax_inverse_temperature": 1.0}``).
++    """
++
++    # ====== Define common fields and constraints ======
++    params_fields = {}
++    fitting_bounds = {}
++
++    # -- Handle actor / critic learning-rate fields --
++    _add_actor_critic_learning_rate_fields(params_fields, fitting_bounds)
++
++    # -- Handle choice kernel fields (reuse the Q-learning helper) --
++    _add_choice_kernel_fields(params_fields, fitting_bounds, choice_kernel)
++
++    # -- Handle action selection fields (softmax; reuse the Q-learning helper) --
++    _add_action_selection_fields(params_fields, fitting_bounds, "softmax")
++
++    # ====== Dynamically create the pydantic models =====
++    return create_pydantic_models_dynamic(params_fields, fitting_bounds)
++
++
++def _add_actor_critic_learning_rate_fields(params_fields, fitting_bounds):
++    """Add actor and critic learning-rate fields to params_fields and fitting_bounds."""
++    params_fields["learn_rate_actor"] = (
++        float,
++        Field(default=0.3, ge=0.0, le=1.0, description="Actor (policy) learning rate"),
++    )
++    fitting_bounds["learn_rate_actor"] = (0.0, 1.0)
++
++    params_fields["learn_rate_critic"] = (
++        float,
++        Field(default=0.3, ge=0.0, le=1.0, description="Critic (state-value) learning rate"),
++    )
++    fitting_bounds["learn_rate_critic"] = (0.0, 1.0)
+diff --git a/tests/test_ActorCritic.py b/tests/test_ActorCritic.py
+new file mode 100644
+index 0000000..853dc73
+--- /dev/null
++++ b/tests/test_ActorCritic.py
+@@ -0,0 +1,88 @@
++"""Testing the actor-critic model"""
++
++import multiprocessing as mp
++import os
++import unittest
++
++import numpy as np
++from aind_behavior_gym.dynamic_foraging.task import CoupledBlockTask
++
++from aind_dynamic_foraging_models.generative_model import ForagerActorCritic
++
++
++class TestActorCritic(unittest.TestCase):
++    """Testing the actor-critic model"""
++
++    def test_actor_critic(self):
++        """Test generative simulation and MLE parameter recovery of the actor-critic model."""
++        # Create results directory if it doesn't exist
++        os.makedirs("tests/results", exist_ok=True)
++
++        # -- Create task and forager --
++        forager = ForagerActorCritic(choice_kernel="none", seed=42)
++        forager.set_params(
++            learn_rate_actor=0.5,
++            learn_rate_critic=0.3,
++            softmax_inverse_temperature=1.0,  # Clamped during fitting (see below)
++            biasL=0.0,
++        )
++        task = CoupledBlockTask(reward_baiting=True, num_trials=300, seed=42)
++
++        # -- 1. Generative run --
++        forager.perform(task)
++        ground_truth_params = forager.params.model_dump()
++        ground_truth_choice_prob = forager.choice_prob
++
++        # --    1.1 test figure --
++        fig, axes = forager.plot_session(if_plot_latent=True)
++        fig.savefig("tests/results/test_ActorCritic.png")
++        self.assertIsNotNone(fig)
++
++        # --    1.2 latent variables should have no NaNs after the first trial --
++        self.assertFalse(np.isnan(forager.actor_preference[:, 1:]).any())
++        self.assertFalse(np.isnan(forager.value[1:]).any())
++
++        # --    1.3 make sure histories match between agent and env --
++        np.testing.assert_array_equal(forager.choice_history, forager.task.get_choice_history())
++        np.testing.assert_array_equal(forager.reward_history, forager.task.get_reward_history())
++
++        # -- 2. Parameter recovery --
++        choice_history = forager.get_choice_history()
++        reward_history = forager.get_reward_history()
++
++        # --    2.1 closed-loop should recover choice_prob exactly with the same params --
++        forager.perform_closed_loop(choice_history, reward_history)
++        np.testing.assert_array_almost_equal(forager.choice_prob, ground_truth_choice_prob)
++
++        # --    2.2 model fitting --
++        # NOTE: learn_rate_actor and beta are not jointly identifiable, so we clamp beta.
++        forager = ForagerActorCritic(choice_kernel="none", seed=42)
++        fitting_result, _ = forager.fit(
++            choice_history,
++            reward_history,
++            clamp_params={"softmax_inverse_temperature": 1.0, "biasL": 0.0},
++            DE_kwargs=dict(
++                workers=mp.cpu_count(),
++                disp=False,
++                seed=np.random.default_rng(42),
++                polish=True,
++            ),
++        )
++
++        assert fitting_result.success
++
++        fit_names = fitting_result.fit_settings["fit_names"]
++        ground_truth = [ground_truth_params[name] for name in fit_names]
++        print(f"\nNum of trials: {len(choice_history)}")
++        print(f"Fitted parameters: {fit_names}")
++        print(f'Ground truth: {[f"{num:.4f}" for num in ground_truth]}')
++        print(f'Fitted:       {[f"{num:.4f}" for num in fitting_result.x]}')
++        print(f"Likelihood-Per-Trial: {fitting_result.LPT}")
++        print(f"Prediction accuracy full dataset: {fitting_result.prediction_accuracy}\n")
++
++        # The two learning rates should be recovered reasonably well
++        np.testing.assert_array_almost_equal(fitting_result.x, ground_truth, decimal=1)
++
++
++if __name__ == "__main__":
++    unittest.main(verbosity=2)
+diff --git a/tests/test_get_forager.py b/tests/test_get_forager.py
+index 0c06dd9..163f336 100644
+--- a/tests/test_get_forager.py
++++ b/tests/test_get_forager.py
+@@ -28,7 +28,8 @@ class TestGetForager(unittest.TestCase):
+         print(f"\nAvailable forager classes: {forager_collection.FORAGER_CLASSES}")
+         forager_df = forager_collection.get_all_foragers()
+         print(forager_df)
+-        self.assertEqual(len(forager_df), 42)
++        # 42 original foragers + 3 ActorCritic variants (choice_kernel none/one_step/full)
++        self.assertEqual(len(forager_df), 45)
+ 
+ 
+ if __name__ == "__main__":

--- a/src/aind_dynamic_foraging_models/generative_model/__init__.py
+++ b/src/aind_dynamic_foraging_models/generative_model/__init__.py
@@ -1,6 +1,7 @@
 """Package for generative models of dynamic foraging behavior"""
 
 # Register the forager classes here
+from .forager_actor_critic import ForagerActorCritic  # noqa: F401
 from .forager_compare_threshold import ForagerCompareThreshold  # noqa: F401
 from .forager_loss_counting import ForagerLossCounting  # noqa: F401
 from .forager_q_learning import ForagerQLearning  # noqa: F401

--- a/src/aind_dynamic_foraging_models/generative_model/forager_actor_critic.py
+++ b/src/aind_dynamic_foraging_models/generative_model/forager_actor_critic.py
@@ -34,9 +34,10 @@ class ForagerActorCritic(DynamicForagingAgentMLEBase):
     def __init__(
         self,
         choice_kernel: Literal["none", "one_step", "full"] = "none",
-        params: dict = {},
+        params: dict | None = None,
         **kwargs,
     ):
+        params = {} if params is None else params
         """Init
 
         Parameters

--- a/src/aind_dynamic_foraging_models/generative_model/forager_actor_critic.py
+++ b/src/aind_dynamic_foraging_models/generative_model/forager_actor_critic.py
@@ -1,0 +1,203 @@
+"""Actor-critic foraging model with MLE fitting.
+
+This implements the classic (Sutton & Barto) actor-critic architecture adapted to a
+two-armed dynamic foraging task, following the same design pattern as
+:class:`~aind_dynamic_foraging_models.generative_model.forager_q_learning.ForagerQLearning`
+so that it plugs directly into the existing MLE / differential-evolution fitting pipeline.
+
+Two latent variables are tracked:
+
+- **Actor** ``H``: a per-action preference. Actions are selected by a softmax over ``H``
+  (plus an optional left bias and choice kernel).
+- **Critic** ``V``: a single (state-less) state value that serves as a reward baseline.
+
+Both are taught by the same TD error ``delta_t = reward_t - V_{t-1}`` (there is no
+bootstrap term because the task is effectively a single-state bandit). See
+:func:`~aind_dynamic_foraging_models.generative_model.learn_functions.learn_actor_critic`.
+"""
+
+# %%
+from typing import Literal
+
+import numpy as np
+from aind_behavior_gym.dynamic_foraging.task import L, R
+
+from .act_functions import act_softmax
+from .base import DynamicForagingAgentMLEBase
+from .learn_functions import learn_actor_critic, learn_choice_kernel
+from .params.forager_actor_critic_params import generate_pydantic_actor_critic_params
+
+
+class ForagerActorCritic(DynamicForagingAgentMLEBase):
+    """The family of actor-critic models (softmax actor + state-value critic)."""
+
+    def __init__(
+        self,
+        choice_kernel: Literal["none", "one_step", "full"] = "none",
+        params: dict = {},
+        **kwargs,
+    ):
+        """Init
+
+        Parameters
+        ----------
+        choice_kernel : Literal["none", "one_step", "full"], optional
+            Choice kernel type, by default "none"
+            If "none", no choice kernel will be included in the model.
+            If "one_step", choice_kernel_step_size will be set to 1.0, i.e., only the last choice
+                affects the choice kernel. (Bari2019)
+            If "full", both choice_kernel_step_size and choice_kernel_relative_weight
+            will be included during fitting.
+        params: dict, optional
+            Initial parameters of the model, by default {}.
+            See the generated Pydantic model in forager_actor_critic_params.py for the full
+            list of parameters (learn_rate_actor, learn_rate_critic, biasL,
+            softmax_inverse_temperature, and optionally choice-kernel parameters).
+
+        Notes
+        -----
+        The action selection is always a softmax over the actor preferences, so the
+        actor's learning-rate scale (``learn_rate_actor``) trades off with the softmax
+        inverse temperature (``softmax_inverse_temperature``). These are not jointly
+        identifiable; when fitting, it is recommended to clamp the inverse temperature,
+        e.g. ``forager.fit(..., clamp_params={"softmax_inverse_temperature": 1.0})``.
+        """
+        # -- Pack the agent_kwargs --
+        self.agent_kwargs = dict(
+            choice_kernel=choice_kernel,
+        )  # Note that the class and self.agent_kwargs fully define the agent
+
+        # -- Initialize the model parameters --
+        super().__init__(agent_kwargs=self.agent_kwargs, params=params, **kwargs)
+
+        # -- Some agent-family-specific variables --
+        self.fit_choice_kernel = False
+
+    def _get_params_model(self, agent_kwargs):
+        """Implement the base class method to dynamically generate Pydantic models
+        for parameters and fitting bounds for the actor-critic agent.
+        """
+        return generate_pydantic_actor_critic_params(**agent_kwargs)
+
+    def get_agent_alias(self):
+        """Get the agent alias"""
+        _ck = {"none": "", "one_step": "_CK1", "full": "_CKfull"}[
+            self.agent_kwargs["choice_kernel"]
+        ]
+        return "ActorCritic" + _ck
+
+    def _reset(self):
+        """Reset the agent"""
+        # --- Call the base class reset ---
+        super()._reset()
+
+        # --- Agent family specific variables ---
+        # Latent variables have n_trials + 1 length to capture the update
+        # after the last trial (consistent with ForagerQLearning).
+        # Actor preference H (one per action)
+        self.actor_preference = np.full([self.n_actions, self.n_trials + 1], np.nan)
+        self.actor_preference[:, 0] = 0  # Initial actor preferences as 0
+
+        # Critic state value V (scalar, state-less bandit)
+        self.value = np.full(self.n_trials + 1, np.nan)
+        self.value[0] = 0  # Initial value as 0
+
+        # Always initialize choice_kernel with nan, even if choice_kernel = "none"
+        self.choice_kernel = np.full([self.n_actions, self.n_trials + 1], np.nan)
+        self.choice_kernel[:, 0] = 0  # Initial choice kernel as 0
+
+    def act(self, _):
+        """Action selection (softmax over actor preferences)"""
+        # Handle choice kernel
+        if self.agent_kwargs["choice_kernel"] == "none":
+            choice_kernel = None
+            choice_kernel_relative_weight = None
+        else:
+            choice_kernel = self.choice_kernel[:, self.trial]
+            choice_kernel_relative_weight = self.params.choice_kernel_relative_weight
+
+        # Action selection: the actor preference plays the role of "q_value" in the softmax
+        choice, choice_prob = act_softmax(
+            q_value_t=self.actor_preference[:, self.trial],
+            softmax_inverse_temperature=self.params.softmax_inverse_temperature,
+            bias_terms=np.array([self.params.biasL, 0]),
+            # -- Choice kernel --
+            choice_kernel=choice_kernel,
+            choice_kernel_relative_weight=choice_kernel_relative_weight,
+            rng=self.rng,
+        )
+
+        return choice, choice_prob
+
+    def learn(self, _observation, choice, reward, _next_observation, done):
+        """Update actor preferences and critic value.
+
+        Note that self.trial already increased by 1 before learn() in the base class,
+        so the policy used to make this trial's choice is choice_prob[:, self.trial - 1].
+        """
+        # The policy (choice probability) that was actually used to make this choice
+        policy_prob = self.choice_prob[:, self.trial - 1]
+
+        # Update actor preference and critic value
+        self.actor_preference[:, self.trial], self.value[self.trial] = learn_actor_critic(
+            choice=choice,
+            reward=reward,
+            actor_preference_tminus1=self.actor_preference[:, self.trial - 1],
+            value_tminus1=self.value[self.trial - 1],
+            choice_prob_t=policy_prob,
+            learn_rates=[self.params.learn_rate_actor, self.params.learn_rate_critic],
+        )
+
+        # Update choice kernel, if used
+        if self.agent_kwargs["choice_kernel"] != "none":
+            self.choice_kernel[:, self.trial] = learn_choice_kernel(
+                choice=choice,
+                choice_kernel_tminus1=self.choice_kernel[:, self.trial - 1],
+                choice_kernel_step_size=self.params.choice_kernel_step_size,
+            )
+
+    def get_latent_variables(self):
+        return {
+            "actor_preference": self.actor_preference.tolist(),
+            "value": self.value.tolist(),
+            "choice_kernel": self.choice_kernel.tolist(),
+            "choice_prob": self.choice_prob.tolist(),
+        }
+
+    def plot_latent_variables(self, ax, if_fitted=False):
+        """Plot actor preferences and critic value"""
+        if if_fitted:
+            style = dict(lw=2, ls=":")
+            prefix = "fitted_"
+        else:
+            style = dict(lw=0.5)
+            prefix = ""
+
+        x = np.arange(self.n_trials + 1) + 1  # When plotting, we start from 1
+
+        # -- Actor preferences --
+        ax.plot(x, self.actor_preference[L, :], label=f"{prefix}H(L)", color="red", **style)
+        ax.plot(x, self.actor_preference[R, :], label=f"{prefix}H(R)", color="blue", **style)
+
+        # -- Critic value (shared baseline) on a twin axis for readability --
+        ax_value = ax.twinx() if not hasattr(ax, "_ac_value_twin") else ax._ac_value_twin
+        ax._ac_value_twin = ax_value
+        ax_value.plot(x, self.value, label=f"{prefix}V", color="black", **style)
+        ax_value.set_ylabel("critic value V")
+
+        # Add choice kernel, if used
+        if self.agent_kwargs["choice_kernel"] != "none":
+            ax.plot(
+                x,
+                self.choice_kernel[L, :],
+                label=f"{prefix}choice_kernel(L)",
+                color="purple",
+                **style,
+            )
+            ax.plot(
+                x,
+                self.choice_kernel[R, :],
+                label=f"{prefix}choice_kernel(R)",
+                color="cyan",
+                **style,
+            )

--- a/src/aind_dynamic_foraging_models/generative_model/foragers.py
+++ b/src/aind_dynamic_foraging_models/generative_model/foragers.py
@@ -16,6 +16,7 @@ class ForagerCollection:
         "ForagerQLearning",
         "ForagerLossCounting",
         "ForagerCompareThreshold",
+        "ForagerActorCritic",
     ]
 
     FORAGER_PRESETS = {
@@ -60,6 +61,13 @@ class ForagerCollection:
         "CompareToThreshold": dict(
             description="Compare-to-threshold foraging model",
             agent_class="ForagerCompareThreshold",
+            agent_kwargs=dict(
+                choice_kernel="none",
+            ),
+        ),
+        "ActorCritic": dict(
+            description="Vanilla actor-critic model (softmax actor + state-value critic)",
+            agent_class="ForagerActorCritic",
             agent_kwargs=dict(
                 choice_kernel="none",
             ),

--- a/src/aind_dynamic_foraging_models/generative_model/learn_functions.py
+++ b/src/aind_dynamic_foraging_models/generative_model/learn_functions.py
@@ -85,3 +85,81 @@ def learn_loss_counting(choice, reward, just_switched, loss_count_tminus1) -> in
         return 1
     else:
         return loss_count_tminus1 + 1
+
+
+def learn_actor_critic(
+    choice,
+    reward,
+    actor_preference_tminus1,
+    value_tminus1,
+    choice_prob_t,
+    learn_rates,
+):
+    """One-step actor-critic update for a (state-less) two-armed foraging task.
+
+    This implements the classic Sutton & Barto actor-critic with a softmax actor:
+
+    1. Critic (state value V) is updated by the TD error. Because the dynamic
+       foraging task is effectively state-less (a single state / bandit), there is
+       no bootstrap term, so the TD error reduces to the reward-prediction error::
+
+           delta_t = reward_t - V_{t-1}
+           V_t     = V_{t-1} + alpha_critic * delta_t
+
+       Here V acts as a running reward baseline shared across actions.
+
+    2. Actor (per-action preference H) is updated along the softmax policy gradient,
+       using the same TD error as the critic's teaching signal::
+
+           H_t(a) = H_{t-1}(a) + alpha_actor * delta_t * (1{a == choice} - pi(a))
+
+       where ``pi`` is the policy (choice probability) that was actually used to
+       select the action on this trial.
+
+    Parameters
+    ----------
+    choice : int
+        This trial's choice (action index).
+    reward : float
+        This trial's reward.
+    actor_preference_tminus1 : np.ndarray
+        Array of old actor preferences H, one entry per action.
+    value_tminus1 : float
+        Old critic state value V (scalar).
+    choice_prob_t : np.ndarray
+        The policy pi (choice probability per action) that was used to make this
+        trial's choice. Used for the softmax policy-gradient term.
+    learn_rates : list
+        Learning rates as [alpha_actor, alpha_critic].
+
+    Returns
+    -------
+    tuple(np.ndarray, float)
+        (new actor preferences H, new critic value V)
+
+    Notes
+    -----
+    The actor's overall scale (alpha_actor) and the policy's softmax inverse
+    temperature (beta) are not jointly identifiable, because both scale the
+    preferences inside the softmax. When fitting, it is therefore recommended to
+    clamp ``softmax_inverse_temperature`` (e.g. to 1.0) and let ``learn_rate_actor``
+    absorb the scale. For that reason, beta is intentionally *not* multiplied into
+    the actor gradient here.
+    """
+    learn_rate_actor, learn_rate_critic = learn_rates[0], learn_rates[1]
+
+    # -- TD error (state-less reward-prediction error) --
+    td_error = reward - value_tminus1
+
+    # -- Critic update --
+    value_t = value_tminus1 + learn_rate_critic * td_error
+
+    # -- Actor update (softmax policy gradient) --
+    K = actor_preference_tminus1.shape[0]
+    choice_onehot = np.zeros(K)
+    choice_onehot[choice] = 1.0
+    actor_preference_t = actor_preference_tminus1 + learn_rate_actor * td_error * (
+        choice_onehot - np.asarray(choice_prob_t)
+    )
+
+    return actor_preference_t, value_t

--- a/src/aind_dynamic_foraging_models/generative_model/params/__init__.py
+++ b/src/aind_dynamic_foraging_models/generative_model/params/__init__.py
@@ -14,6 +14,8 @@ class ParamsSymbols(str, Enum):
     learn_rate = R"$\alpha$"
     learn_rate_rew = R"$\alpha_{rew}$"
     learn_rate_unrew = R"$\alpha_{unr}$"
+    learn_rate_actor = R"$\alpha_{actor}$"
+    learn_rate_critic = R"$\alpha_{critic}$"
     forget_rate_unchosen = R"$\delta$"
     choice_kernel_step_size = R"$\alpha_{ck}$"
     choice_kernel_relative_weight = R"$w_{ck}$"

--- a/src/aind_dynamic_foraging_models/generative_model/params/forager_actor_critic_params.py
+++ b/src/aind_dynamic_foraging_models/generative_model/params/forager_actor_critic_params.py
@@ -1,0 +1,70 @@
+"""Dynamically generate pydantic models for actor-critic agent parameters."""
+
+# %%
+from typing import Literal, Tuple, Type
+
+from pydantic import BaseModel, Field
+
+from .forager_q_learning_params import (
+    _add_action_selection_fields,
+    _add_choice_kernel_fields,
+)
+from .util import create_pydantic_models_dynamic
+
+
+def generate_pydantic_actor_critic_params(
+    choice_kernel: Literal["none", "one_step", "full"] = "none",
+) -> Tuple[Type[BaseModel], Type[BaseModel]]:
+    """Dynamically generate Pydantic models for actor-critic agent parameters.
+
+    All default values are hard-coded in this function. But when instantiating the model,
+    you can always override the default values, both the params_fields and the fitting bounds.
+
+    Parameters
+    ----------
+    choice_kernel : Literal["none", "one_step", "full"], optional
+        Choice kernel type, by default "none"
+        If "none", no choice kernel will be included in the model.
+        If "one_step", choice_kernel_step_size will be set to 1.0, i.e., only the previous choice
+            affects the choice kernel. (Bari2019)
+        If "full", both choice_kernel_step_size and choice_kernel_relative_weight will be included
+
+    Notes
+    -----
+    The actor-critic agent always uses a softmax actor, so ``biasL`` and
+    ``softmax_inverse_temperature`` (beta) are always included via the shared
+    action-selection helper. Note that ``learn_rate_actor`` and ``beta`` are not
+    jointly identifiable; it is recommended to clamp ``softmax_inverse_temperature``
+    when fitting (e.g. ``clamp_params={"softmax_inverse_temperature": 1.0}``).
+    """
+
+    # ====== Define common fields and constraints ======
+    params_fields = {}
+    fitting_bounds = {}
+
+    # -- Handle actor / critic learning-rate fields --
+    _add_actor_critic_learning_rate_fields(params_fields, fitting_bounds)
+
+    # -- Handle choice kernel fields (reuse the Q-learning helper) --
+    _add_choice_kernel_fields(params_fields, fitting_bounds, choice_kernel)
+
+    # -- Handle action selection fields (softmax; reuse the Q-learning helper) --
+    _add_action_selection_fields(params_fields, fitting_bounds, "softmax")
+
+    # ====== Dynamically create the pydantic models =====
+    return create_pydantic_models_dynamic(params_fields, fitting_bounds)
+
+
+def _add_actor_critic_learning_rate_fields(params_fields, fitting_bounds):
+    """Add actor and critic learning-rate fields to params_fields and fitting_bounds."""
+    params_fields["learn_rate_actor"] = (
+        float,
+        Field(default=0.3, ge=0.0, le=1.0, description="Actor (policy) learning rate"),
+    )
+    fitting_bounds["learn_rate_actor"] = (0.0, 1.0)
+
+    params_fields["learn_rate_critic"] = (
+        float,
+        Field(default=0.3, ge=0.0, le=1.0, description="Critic (state-value) learning rate"),
+    )
+    fitting_bounds["learn_rate_critic"] = (0.0, 1.0)

--- a/tests/test_ActorCritic.py
+++ b/tests/test_ActorCritic.py
@@ -1,0 +1,88 @@
+"""Testing the actor-critic model"""
+
+import multiprocessing as mp
+import os
+import unittest
+
+import numpy as np
+from aind_behavior_gym.dynamic_foraging.task import CoupledBlockTask
+
+from aind_dynamic_foraging_models.generative_model import ForagerActorCritic
+
+
+class TestActorCritic(unittest.TestCase):
+    """Testing the actor-critic model"""
+
+    def test_actor_critic(self):
+        """Test generative simulation and MLE parameter recovery of the actor-critic model."""
+        # Create results directory if it doesn't exist
+        os.makedirs("tests/results", exist_ok=True)
+
+        # -- Create task and forager --
+        forager = ForagerActorCritic(choice_kernel="none", seed=42)
+        forager.set_params(
+            learn_rate_actor=0.5,
+            learn_rate_critic=0.3,
+            softmax_inverse_temperature=1.0,  # Clamped during fitting (see below)
+            biasL=0.0,
+        )
+        task = CoupledBlockTask(reward_baiting=True, num_trials=300, seed=42)
+
+        # -- 1. Generative run --
+        forager.perform(task)
+        ground_truth_params = forager.params.model_dump()
+        ground_truth_choice_prob = forager.choice_prob
+
+        # --    1.1 test figure --
+        fig, axes = forager.plot_session(if_plot_latent=True)
+        fig.savefig("tests/results/test_ActorCritic.png")
+        self.assertIsNotNone(fig)
+
+        # --    1.2 latent variables should have no NaNs after the first trial --
+        self.assertFalse(np.isnan(forager.actor_preference[:, 1:]).any())
+        self.assertFalse(np.isnan(forager.value[1:]).any())
+
+        # --    1.3 make sure histories match between agent and env --
+        np.testing.assert_array_equal(forager.choice_history, forager.task.get_choice_history())
+        np.testing.assert_array_equal(forager.reward_history, forager.task.get_reward_history())
+
+        # -- 2. Parameter recovery --
+        choice_history = forager.get_choice_history()
+        reward_history = forager.get_reward_history()
+
+        # --    2.1 closed-loop should recover choice_prob exactly with the same params --
+        forager.perform_closed_loop(choice_history, reward_history)
+        np.testing.assert_array_almost_equal(forager.choice_prob, ground_truth_choice_prob)
+
+        # --    2.2 model fitting --
+        # NOTE: learn_rate_actor and beta are not jointly identifiable, so we clamp beta.
+        forager = ForagerActorCritic(choice_kernel="none", seed=42)
+        fitting_result, _ = forager.fit(
+            choice_history,
+            reward_history,
+            clamp_params={"softmax_inverse_temperature": 1.0, "biasL": 0.0},
+            DE_kwargs=dict(
+                workers=mp.cpu_count(),
+                disp=False,
+                seed=np.random.default_rng(42),
+                polish=True,
+            ),
+        )
+
+        assert fitting_result.success
+
+        fit_names = fitting_result.fit_settings["fit_names"]
+        ground_truth = [ground_truth_params[name] for name in fit_names]
+        print(f"\nNum of trials: {len(choice_history)}")
+        print(f"Fitted parameters: {fit_names}")
+        print(f'Ground truth: {[f"{num:.4f}" for num in ground_truth]}')
+        print(f'Fitted:       {[f"{num:.4f}" for num in fitting_result.x]}')
+        print(f"Likelihood-Per-Trial: {fitting_result.LPT}")
+        print(f"Prediction accuracy full dataset: {fitting_result.prediction_accuracy}\n")
+
+        # The two learning rates should be recovered reasonably well
+        np.testing.assert_array_almost_equal(fitting_result.x, ground_truth, decimal=1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_get_forager.py
+++ b/tests/test_get_forager.py
@@ -28,7 +28,8 @@ class TestGetForager(unittest.TestCase):
         print(f"\nAvailable forager classes: {forager_collection.FORAGER_CLASSES}")
         forager_df = forager_collection.get_all_foragers()
         print(forager_df)
-        self.assertEqual(len(forager_df), 42)
+        # 42 original foragers + 3 ActorCritic variants (choice_kernel none/one_step/full)
+        self.assertEqual(len(forager_df), 45)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a new **actor-critic** forager (`ForagerActorCritic`) to the generative-model family. It follows the exact same design pattern as `ForagerQLearning`, so it plugs directly into the existing MLE / differential-evolution fitting pipeline (cross-validation, AIC/BIC/LPT, prediction accuracy, plotting) with no changes to the base class.

This complements the existing value-based (Q-learning) and descriptive (loss-counting, compare-to-threshold) models with a **policy-gradient** account of choice behavior, which is a commonly used alternative model class in dynamic-foraging work.

## What's added

A softmax actor + state-value critic, taught by a shared TD error. Because the task is effectively a single-state bandit, the TD error reduces to a reward-prediction error:

- **Critic** `V`: `delta_t = r_t - V_{t-1}`, `V_t = V_{t-1} + alpha_critic * delta_t`
- **Actor** `H` (per-arm preference), softmax policy gradient: `H_t(a) = H_{t-1}(a) + alpha_actor * delta_t * (1{a == choice} - pi(a))`

Action selection reuses `act_softmax`, so it produces `softmax(beta*H + [biasL, 0] + beta*w_ck*CK)` — i.e. the left-bias term and the choice-kernel term are supported out of the box, identically to `Hattori + CK`.

Three variants are exposed via the `choice_kernel` kwarg and registered in `ForagerCollection`:

- `ActorCritic` (no choice kernel)
- `ActorCritic_CK1` (one-step CK, Bari-style)
- `ActorCritic_CKfull` (full CK, Hattori-style)

## Design notes

- `alpha_actor` and the softmax inverse temperature `beta` are **not jointly identifiable** (both scale the preferences inside the softmax). Fitting therefore recommends clamping `beta`, e.g. `clamp_params={"softmax_inverse_temperature": 1.0}`. This is documented in the class docstring and applied in the test. For the same reason, `beta` is intentionally *not* multiplied into the actor gradient.
- No discount factor `gamma`: it has no role in a state-less bandit.
- Consistent with the rest of the family, the agent uses `n_actions = 2` and does not select `IGNORE` on `allow_ignore=True` tasks (same behavior as `ForagerQLearning`).

## Files

New:

- `src/aind_dynamic_foraging_models/generative_model/forager_actor_critic.py`
- `src/aind_dynamic_foraging_models/generative_model/params/forager_actor_critic_params.py`
- `tests/test_ActorCritic.py`

Changed:

- `generative_model/learn_functions.py` — add `learn_actor_critic`
- `generative_model/params/__init__.py` — add `learn_rate_actor` / `learn_rate_critic` symbols
- `generative_model/__init__.py`, `foragers.py` — register class + `ActorCritic` preset
- `tests/test_get_forager.py` — update expected forager count (42 -> 45)

## Testing

- Generative simulation runs on all three tasks (`CoupledBlockTask`, `UncoupledBlockTask`, `RandomWalkTask`); latent variables contain no NaNs; agent/env choice & reward histories match.
- Closed-loop reproduces `choice_prob` exactly for fixed params.
- **MLE parameter recovery** (beta, biasL clamped): `alpha_actor` 0.5 -> 0.493, `alpha_critic` 0.3 -> 0.31. With a full choice kernel, `w_ck` and `step_size` are also recovered in the expected range (CK weight is known to be sensitive).
- `flake8`, `black`, `isort` clean on all new/changed files.
- Existing suite still passes (incl. `test_Hattori` full fitting pipeline); ran via `coverage run -m unittest discover`.

## Checklist

- [x] Follows the existing forager design pattern
- [x] New unit test added (`tests/test_ActorCritic.py`)
- [x] Linters pass (flake8 / black / isort)
- [x] Existing tests pass, no regression
- [ ] Reviewer to confirm whether an `ActorCritic` demo cell should be added to the notebook
